### PR TITLE
fix(ical): improve event titles and descriptions for calendar subscriptions

### DIFF
--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -74,8 +74,8 @@ class ICalController extends Controller
 
             foreach ($trainingUsers as $trainingUser) {
                 $training = $trainingUser->training;
-                $qualification = $trainingUser->position->qualification ?? null;
-                $prefix = ($training->title ?? 'Übung') . ($qualification ? ' (' . $qualification->name . ')' : '');
+                $qualification = $trainingUser->position?->qualification ?? null;
+                $prefix = ($training->title ?: 'Übung') . ($qualification ? ' (' . $qualification->name . ')' : '');
                 $title = $this->serviceTitle($prefix, $training->date, $training->dateEnd ?? null);
                 $content = $training->content ? $this->htmlToPlainText($training->content) : null;
                 $event = $this->buildEvent($title, $training->date, $training->dateEnd ?? null, $training->location ?? null, $content);

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -77,7 +77,8 @@ class ICalController extends Controller
                 $qualification = $trainingUser->position->qualification ?? null;
                 $prefix = ($training->title ?? 'Übung') . ($qualification ? ' (' . $qualification->name . ')' : '');
                 $title = $this->serviceTitle($prefix, $training->date, $training->dateEnd ?? null);
-                $event = $this->buildEvent($title, $training->date, $training->dateEnd ?? null, $training->location ?? null, $training->content ?? null);
+                $content = $training->content ? $this->htmlToPlainText($training->content) : null;
+                $event = $this->buildEvent($title, $training->date, $training->dateEnd ?? null, $training->location ?? null, $content);
                 $event->setStatus(EventStatus::CONFIRMED());
                 $events[] = $event;
             }
@@ -92,6 +93,21 @@ class ICalController extends Controller
             ->header('Cache-Control', 'no-cache, no-store, must-revalidate')
             ->header('Pragma', 'no-cache')
             ->header('Expires', '0');
+    }
+
+    private function htmlToPlainText(string $html): string
+    {
+        $text = preg_replace('/>\s+</u', '><', $html);
+        $text = preg_replace('/<br[^>]*>/i', "\n", $text);
+        $text = preg_replace('/<\/(p|h[1-6]|div|li|ul|ol)[^>]*>/i', "\n", $text);
+        $text = preg_replace('/<(p|h[1-6]|div|li|ul|ol)[^>]*>/i', '', $text);
+        $text = strip_tags($text);
+        $text = str_replace('&nbsp;', ' ', $text);
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $text = str_replace("\u{00A0}", ' ', $text);
+        $text = preg_replace('/^[ \t]+$/m', '', $text);
+        $text = preg_replace("/\n{3,}/", "\n\n", $text);
+        return trim($text);
     }
 
     private function serviceTitle(string $prefix, $date, $dateEnd, ?string $suffix = null): string

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -37,7 +37,7 @@ class ICalController extends Controller
             foreach ($servicePositions as $position) {
                 $service = $position->service;
                 $prefix = 'Dienst' . ($position->qualification ? ' (' . $position->qualification->name . ')' : '');
-                $title = $this->serviceTitle($prefix, $service->date, $service->dateEnd ?? null, $service->comment ?? null);
+                $title = $this->serviceTitle($prefix, $service->date, $service->dateEnd ?? null, $position->comment ?? null);
                 $event = $this->buildEvent($title, $service->date, $service->dateEnd ?? null, $service->location ?? null, $service->comment ?? null);
                 $event->setStatus(EventStatus::CONFIRMED());
                 $events[] = $event;
@@ -59,7 +59,7 @@ class ICalController extends Controller
                 }
 
                 $prefix = 'Dienst (nicht bestätigt)' . ($position->qualification ? ' (' . $position->qualification->name . ')' : '');
-                $title = $this->serviceTitle($prefix, $service->date, $service->dateEnd ?? null, $service->comment ?? null);
+                $title = $this->serviceTitle($prefix, $service->date, $service->dateEnd ?? null, $position->comment ?? null);
                 $event = $this->buildEvent($title, $service->date, $service->dateEnd ?? null, $service->location ?? null, $service->comment ?? null);
                 $event->setStatus(EventStatus::TENTATIVE());
                 $events[] = $event;
@@ -94,14 +94,15 @@ class ICalController extends Controller
             ->header('Expires', '0');
     }
 
-    private function serviceTitle(string $prefix, $date, $dateEnd, ?string $description = null): string
+    private function serviceTitle(string $prefix, $date, $dateEnd, ?string $suffix = null): string
     {
         $title = $prefix . ': ' . $date->format('H:i');
         if (!empty($dateEnd)) {
             $title .= ' – ' . $dateEnd->format('H:i');
         }
-        if (!empty($description)) {
-            $title .= ' ' . $description;
+        $title .= ' Uhr';
+        if (!empty($suffix)) {
+            $title .= ' (' . $suffix . ')';
         }
         return $title;
     }

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -76,7 +76,7 @@ class ICalController extends Controller
                 $training = $trainingUser->training;
                 $qualification = $trainingUser->position->qualification ?? null;
                 $prefix = ($training->title ?? 'Übung') . ($qualification ? ' (' . $qualification->name . ')' : '');
-                $title = $this->serviceTitle($prefix, $training->date, $training->dateEnd ?? null, $training->content ?? null);
+                $title = $this->serviceTitle($prefix, $training->date, $training->dateEnd ?? null);
                 $event = $this->buildEvent($title, $training->date, $training->dateEnd ?? null, $training->location ?? null, $training->content ?? null);
                 $event->setStatus(EventStatus::CONFIRMED());
                 $events[] = $event;
@@ -94,7 +94,7 @@ class ICalController extends Controller
             ->header('Expires', '0');
     }
 
-    private function serviceTitle(string $prefix, $date, $dateEnd, ?string $description): string
+    private function serviceTitle(string $prefix, $date, $dateEnd, ?string $description = null): string
     {
         $title = $prefix . ': ' . $date->format('H:i');
         if (!empty($dateEnd)) {


### PR DESCRIPTION
## iCal Feed Fixes

- **Service title**: add position comment in parentheses, append "Uhr" after time
- **Service description**: move service comment out of title, description only
- **Training title**: remove content from title, description only
- **Training description**: strip HTML tags for plain text output
- **Robustness**: nullsafe `position` relation on training entries, `?:` fallback for empty training title
